### PR TITLE
Add Telegram integration with score sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Crypto Jump Telegram Game
+
+Crypto Jump is a simple Doodle Jump style game built for Telegram Web Apps. The game is written in vanilla JavaScript and can be launched inside a Telegram chat via a bot.
+
+## Running Locally
+
+Open `index.html` in a web browser to play the game locally. Use the arrow keys on desktop or tilt your phone on mobile to move the character.
+
+## Telegram Integration
+
+To use the game in Telegram:
+
+1. Create a Telegram bot with [@BotFather](https://t.me/BotFather).
+2. Host the contents of this repository on a web server accessible via HTTPS.
+3. Set the bot's **Web App** URL to your hosted `index.html`.
+4. In the chat with your bot, send the command that opens the Web App.
+
+When the player loses, the final score is sent back to the bot using `Telegram.WebApp.sendData`.

--- a/game.js
+++ b/game.js
@@ -61,7 +61,12 @@ function update() {
   });
 
   if (player.y > canvas.height) {
-    alert('Game Over! Score: ' + Math.floor(score / 100));
+    const finalScore = Math.floor(score / 100);
+    alert('Game Over! Score: ' + finalScore);
+    if (window.Telegram && Telegram.WebApp && Telegram.WebApp.sendData) {
+      Telegram.WebApp.sendData(JSON.stringify({ score: finalScore }));
+      Telegram.WebApp.close();
+    }
     document.location.reload();
   }
 }


### PR DESCRIPTION
## Summary
- send game over score to Telegram when the player loses
- add a README with instructions for running locally and in Telegram

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856006b35588329b9fbcf73f9018e0b