### PR TITLE
Add starter platform and power-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Crypto Jump is a simple Doodle Jump style game built for Telegram Web Apps. The game is written in vanilla JavaScript and can be launched inside a Telegram chat via a bot.
 
+## New Features
+
+- Guaranteed starting platform so you never fall right away.
+- Difficulty scales with your score: fewer platforms and more hazards appear over time.
+- Look out for power-ups on platforms: springs for a higher jump, rockets for a huge boost and shields that save you from one fall or enemy.
+
 ## Running Locally
 
 Open `index.html` in a web browser to play the game locally. Use the arrow keys on desktop or tilt your phone on mobile to move the character.

--- a/index.html
+++ b/index.html
@@ -7,10 +7,11 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div id="ui">
-    <span id="score">Score: 0</span>
-    <span id="record">Record: 0</span>
-  </div>
+    <div id="ui">
+      <span id="score">Score: 0</span>
+      <span id="record">Record: 0</span>
+      <span id="shieldUI" style="display:none">Shield!</span>
+    </div>
   <button id="startBtn">Start</button>
   <button id="restartBtn">Restart</button>
   <div id="gameOver">Game Over!</div>


### PR DESCRIPTION
## Summary
- guarantee a safe starting platform
- ramp difficulty over time and spawn fewer platforms
- add rocket, spring and shield power-ups
- display active shield status in the UI
- document new features

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685602c64be4832984ef0110182261a9