### PR TITLE
Improve mobile controls and adjust boosts

### DIFF
--- a/game.js
+++ b/game.js
@@ -185,12 +185,12 @@ function update() {
         }
       } else {
         let bounce = player.jump;
-        if (p.boost === 'spring') bounce = player.jump * 1.5;
+        if (p.boost === 'spring') bounce = player.jump * 0.75;
         if (p.boost === 'rocket') {
           rocketActive = true;
           rocketStartTime = Date.now();
         }
-        if (rocketActive) bounce = player.jump * 4;
+        if (rocketActive) bounce = player.jump * 2;
         player.dy = bounce;
         if (p.boost === 'shield') {
           hasShield = true;
@@ -234,7 +234,7 @@ function update() {
     if (Date.now() - rocketStartTime > boostDuration) {
       rocketActive = false;
     } else {
-      player.dy = player.jump * 4;
+      player.dy = player.jump * 2;
     }
   }
 
@@ -385,6 +385,23 @@ document.addEventListener('keydown', e => {
 document.addEventListener('keyup', e => {
   if (e.key === 'ArrowLeft') keys.left = false;
   else if (e.key === 'ArrowRight') keys.right = false;
+});
+
+function handleTouch(e) {
+  if (e.touches && e.touches[0]) {
+    const x = e.touches[0].clientX;
+    const mid = window.innerWidth / 2;
+    keys.left = x < mid;
+    keys.right = x >= mid;
+  }
+  e.preventDefault();
+}
+
+document.addEventListener('touchstart', handleTouch, { passive: false });
+document.addEventListener('touchmove', handleTouch, { passive: false });
+document.addEventListener('touchend', () => {
+  keys.left = false;
+  keys.right = false;
 });
 
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>Telegram Doodle Jump</title>
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,7 @@
-body {
+html, body {
   margin: 0;
   overflow: hidden;
+  height: 100%;
   background-color: #0b0f1a;
   font-family: "Courier New", monospace;
   color: #00e5ff;
@@ -10,6 +11,7 @@ canvas {
   display: block;
   margin: 0 auto;
   background: transparent;
+  touch-action: none;
 }
 
 #ui {


### PR DESCRIPTION
## Summary
- reduce rocket and spring boost strength
- add touch controls for smartphones
- make the page occupy full screen and disable zoom

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68560b354d888329aec6d3d03f9743fb