### PR TITLE
Implement fullscreen and timed boosts

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,7 @@
 html, body {
   margin: 0;
   overflow: hidden;
+  width: 100%;
   height: 100%;
   background-color: #0b0f1a;
   font-family: "Courier New", monospace;
@@ -12,6 +13,8 @@ canvas {
   margin: 0 auto;
   background: transparent;
   touch-action: none;
+  width: 100%;
+  height: 100%;
 }
 
 #ui {

--- a/telegram.js
+++ b/telegram.js
@@ -1,6 +1,8 @@
 window.addEventListener('DOMContentLoaded', () => {
   if (window.Telegram && Telegram.WebApp) {
     Telegram.WebApp.ready();
-    Telegram.WebApp.expand();
+    if (Telegram.WebApp.requestFullscreen) {
+      Telegram.WebApp.requestFullscreen();
+    }
   }
 });


### PR DESCRIPTION
## Summary
- make Mini App enter fullscreen automatically
- ensure body and canvas fill entire window
- update boost duration logic
- adjust platform generation for screen height

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856151d4f9883298a7fb98e6f5d8844