### PR TITLE
Add menu and settings placeholders

### DIFF
--- a/main.css
+++ b/main.css
@@ -119,3 +119,41 @@ body {
   padding: 10px 0;
 }
 .bottom-nav span { font-size: 1.5rem; }
+.bottom-nav a {
+  font-size: 1.5rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.top-right a.icon {
+  color: inherit;
+  text-decoration: none;
+}
+
+.menu-list {
+  list-style: none;
+  padding: 0 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.menu-list li {
+  background: rgba(0,0,0,0.5);
+  padding: 8px 12px;
+  border-radius: 8px;
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  padding: 0 20px;
+}
+
+.settings-form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+  gap: 5px;
+}

--- a/menu.html
+++ b/menu.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-  <title>Crypto Jump</title>
+  <title>Меню · Crypto Jump</title>
   <link rel="stylesheet" href="main.css" />
 </head>
 <body>
@@ -11,30 +11,21 @@
   <header class="top-bar">
     <div class="energy"><span class="icon">🔋</span><span class="value">5</span></div>
     <div class="top-right">
-      <div class="avatar">
-        <span class="avatar-indicator">3</span>
-      </div>
-      <a class="icon" href="menu.html">👥</a>
+      <div class="avatar"><span class="avatar-indicator">3</span></div>
       <a class="icon" href="settings.html">⚙️</a>
     </div>
   </header>
   <main class="content">
-    <div class="center-sphere">
-      <a class="play-btn" href="index.html">Play</a>
-    </div>
-    <div class="modes">
-      <div class="mode turquoise">&nbsp;</div>
-      <div class="mode gold">&nbsp;</div>
-      <div class="mode purple">&nbsp;</div>
-    </div>
+    <h1>📋 Меню</h1>
+    <ul class="menu-list">
+      <li>Реф. система <em>заглушка</em></li>
+      <li>Баланс TON: <span id="ton-balance">—</span></li>
+      <li><a href="shop.html">Магазин</a> <em>заглушка</em></li>
+      <li>Рейтинг игроков: <span class="nick">@Viessory</span></li>
+    </ul>
   </main>
-  <footer class="bottom-info">
-    <div class="league">Земная Лига</div>
-    <div class="trophies">Сезон 1 · 🏆130</div>
-    <div class="progress"><div class="progress-bar"></div></div>
-  </footer>
   <nav class="bottom-nav">
-    <span>🏠</span>
+    <a href="main.html">🏠</a>
     <span>🪖</span>
     <span>🏆</span>
     <span>🧊</span>

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Настройки · Crypto Jump</title>
+  <link rel="stylesheet" href="main.css" />
+</head>
+<body>
+  <div class="space"></div>
+  <header class="top-bar">
+    <div class="energy"><span class="icon">🔋</span><span class="value">5</span></div>
+    <div class="top-right">
+      <a class="icon" href="menu.html">⬅️</a>
+    </div>
+  </header>
+  <main class="content">
+    <h1>⚙️ Настройки</h1>
+    <form class="settings-form">
+      <label>Громкость
+        <input type="range" min="0" max="100" value="50" />
+      </label>
+      <label>
+        <input type="checkbox" checked /> Уведомления
+      </label>
+      <label>Визуальная тема
+        <select>
+          <option>Светлая</option>
+          <option>Тёмная</option>
+        </select>
+      </label>
+      <label>Скин ракеты
+        <select>
+          <option>Стандарт</option>
+          <option>Красная</option>
+          <option>Синяя</option>
+        </select>
+      </label>
+    </form>
+  </main>
+  <nav class="bottom-nav">
+    <a href="main.html">🏠</a>
+    <span>🪖</span>
+    <span>🏆</span>
+    <span>🧊</span>
+    <a href="menu.html">👤</a>
+  </nav>
+  <script src="telegram.js"></script>
+</body>
+</html>

--- a/shop.html
+++ b/shop.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Магазин · Crypto Jump</title>
+  <link rel="stylesheet" href="main.css" />
+</head>
+<body>
+  <div class="space"></div>
+  <header class="top-bar">
+    <div class="energy"><span class="icon">🔋</span><span class="value">5</span></div>
+    <div class="top-right">
+      <a class="icon" href="menu.html">⬅️</a>
+    </div>
+  </header>
+  <main class="content">
+    <h1>🛒 Магазин</h1>
+    <p>Раздел в разработке…</p>
+  </main>
+  <nav class="bottom-nav">
+    <a href="main.html">🏠</a>
+    <span>🪖</span>
+    <span>🏆</span>
+    <span>🧊</span>
+    <a href="menu.html">👤</a>
+  </nav>
+  <script src="telegram.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `menu.html`, `shop.html`, and `settings.html` placeholder pages
- link menu and settings from `main.html`
- style menu list and settings form in `main.css`
- load `telegram.js` on the new pages for fullscreen support

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6856185bea888329b376fb3c2008e835