### PR TITLE
Add simple free Doodle Jump mode

### DIFF
--- a/src/components/SpaceJumpMainMenu.jsx
+++ b/src/components/SpaceJumpMainMenu.jsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "./ui/button";
+import DoodleJumpGame from "./game/DoodleJumpGame";
 
 export default function SpaceJumpMainMenu() {
   const [screen, setScreen] = useState("menu");
@@ -22,12 +23,13 @@ export default function SpaceJumpMainMenu() {
     profile: "Профиль",
     ton: "О проекте",
     settings: "Настройки",
+    free: "Бесплатная игра",
   };
 
   const ScreenContent = () => {
     switch (screen) {
       case "play":
-        return <GameModeMenu />;
+        return <GameModeMenu onFree={() => setScreen("free")} />;
       case "list":
         return <Leaderboard />;
       case "trophy":
@@ -36,6 +38,8 @@ export default function SpaceJumpMainMenu() {
         return <Shop />;
       case "profile":
         return <Profile />;
+      case "free":
+        return <DoodleJumpGame onExit={() => setScreen("menu")} />;
       case "ton":
         return <About />;
       case "settings":
@@ -229,19 +233,19 @@ function IconButton({ icon, onClick, ariaLabel }) {
   );
 }
 
-function GameModeMenu() {
-  const modes = [
-    "Free – играть бесплатно",
-    "Выжить – вход 1 TON",
-  ];
+function GameModeMenu({ onFree }) {
   return (
     <div className="space-y-4 text-white">
-      {modes.map((m) => (
-        <div key={m} className="flex justify-between items-center bg-white/10 p-4 rounded-md">
-          <span>{m}</span>
-          <span className="text-xs px-2 py-1 bg-yellow-500 text-black rounded">SOON</span>
-        </div>
-      ))}
+      <div
+        onClick={onFree}
+        className="flex justify-between items-center bg-white/10 p-4 rounded-md cursor-pointer hover:bg-white/20"
+      >
+        <span>Free – играть бесплатно</span>
+      </div>
+      <div className="flex justify-between items-center bg-white/10 p-4 rounded-md opacity-50">
+        <span>Выжить – вход 1 TON</span>
+        <span className="text-xs px-2 py-1 bg-yellow-500 text-black rounded">SOON</span>
+      </div>
     </div>
   );
 }

--- a/src/components/game/DoodleJumpGame.jsx
+++ b/src/components/game/DoodleJumpGame.jsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Button } from "../ui/button";
+
+export default function DoodleJumpGame({ onExit }) {
+  const canvasRef = useRef(null);
+  const [gameOver, setGameOver] = useState(false);
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext("2d");
+    canvas.width = 320;
+    canvas.height = 480;
+
+    const player = { x: canvas.width / 2 - 20, y: 400, vy: -8, w: 40, h: 40 };
+    const platforms = [];
+    const pW = 60;
+    const pH = 10;
+    for (let i = 0; i < 7; i++) {
+      platforms.push({ x: Math.random() * (canvas.width - pW), y: i * 80 });
+    }
+
+    const keys = {};
+    const keyDown = (e) => {
+      keys[e.key] = true;
+    };
+    const keyUp = (e) => {
+      keys[e.key] = false;
+    };
+    window.addEventListener("keydown", keyDown);
+    window.addEventListener("keyup", keyUp);
+
+    let animId;
+    const loop = () => {
+      player.vy += 0.2;
+      player.y += player.vy;
+      if (keys["ArrowLeft"]) player.x -= 4;
+      if (keys["ArrowRight"]) player.x += 4;
+      if (player.x < -player.w) player.x = canvas.width;
+      if (player.x > canvas.width) player.x = -player.w;
+
+      if (player.vy > 0) {
+        platforms.forEach((p) => {
+          if (
+            player.x + player.w > p.x &&
+            player.x < p.x + pW &&
+            player.y + player.h > p.y &&
+            player.y + player.h < p.y + pH &&
+            player.vy > 0
+          ) {
+            player.vy = -8;
+          }
+        });
+      }
+
+      if (player.y < canvas.height / 2) {
+        const diff = canvas.height / 2 - player.y;
+        player.y = canvas.height / 2;
+        platforms.forEach((p) => {
+          p.y += diff;
+          if (p.y > canvas.height) {
+            p.y = 0;
+            p.x = Math.random() * (canvas.width - pW);
+            setScore((s) => s + 1);
+          }
+        });
+      }
+
+      if (player.y > canvas.height) {
+        setGameOver(true);
+        cancelAnimationFrame(animId);
+        return;
+      }
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = "#fff";
+      ctx.fillRect(player.x, player.y, player.w, player.h);
+      ctx.fillStyle = "#0f0";
+      platforms.forEach((p) => ctx.fillRect(p.x, p.y, pW, pH));
+      ctx.fillStyle = "#fff";
+      ctx.fillText("Score: " + score, 10, 20);
+
+      animId = requestAnimationFrame(loop);
+    };
+    animId = requestAnimationFrame(loop);
+
+    return () => {
+      cancelAnimationFrame(animId);
+      window.removeEventListener("keydown", keyDown);
+      window.removeEventListener("keyup", keyUp);
+    };
+  }, [score]);
+
+  return (
+    <div className="text-white flex flex-col items-center">
+      {gameOver && (
+        <div className="mb-4 text-center">
+          <p className="text-xl">Game Over</p>
+          <p className="mb-2">Score: {score}</p>
+          <Button onClick={onExit}>В меню</Button>
+        </div>
+      )}
+      <canvas ref={canvasRef} className="border border-white" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a basic Doodle Jump-like game implementation
- integrate new game mode into main menu
- allow starting and exiting the free mode

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856664cf1448329b588bbcfce9a4ef9