### PR TITLE
Improve game view and rocket graphics

### DIFF
--- a/src/components/SpaceJumpMainMenu.jsx
+++ b/src/components/SpaceJumpMainMenu.jsx
@@ -50,7 +50,7 @@ export default function SpaceJumpMainMenu() {
   };
 
   return (
-    <div className="relative w-full min-h-screen lg:h-screen bg-black overflow-hidden p-4 md:p-8 flex flex-col items-center max-w-md md:max-w-2xl xl:max-w-none mx-auto">
+    <div className="relative w-screen min-h-screen lg:h-screen bg-black overflow-hidden p-4 md:p-8 flex flex-col items-center mx-auto">
       {/* Новый CSS-анимированный звёздный фон */}
       <div className="absolute inset-0 z-0">
         <div className="stars-layer"></div>
@@ -149,7 +149,9 @@ export default function SpaceJumpMainMenu() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="absolute inset-0 z-20 flex flex-col bg-black/70 backdrop-blur-lg"
+            className={`absolute inset-0 z-20 flex flex-col ${
+              screen === "free" ? "bg-black" : "bg-black/70 backdrop-blur-lg"
+            }`}
           >
             <div className="flex justify-between items-center px-4 md:px-8 pt-4 md:pt-8">
               <button
@@ -165,8 +167,12 @@ export default function SpaceJumpMainMenu() {
               <span className="w-12 h-12" />
             </div>
             <div className="flex grow items-center justify-center z-20">
-              <div className="w-full max-w-md">
-                <h2 className="text-center text-white text-2xl mb-4">{titles[screen]}</h2>
+              <div className={`w-full ${screen === "free" ? "h-full" : "max-w-md"}`}>
+                {screen !== "free" && (
+                  <h2 className="text-center text-white text-2xl mb-4">
+                    {titles[screen]}
+                  </h2>
+                )}
                 <ScreenContent />
               </div>
             </div>

--- a/src/components/game/DoodleJumpGame.jsx
+++ b/src/components/game/DoodleJumpGame.jsx
@@ -9,10 +9,21 @@ export default function DoodleJumpGame({ onExit }) {
   useEffect(() => {
     const canvas = canvasRef.current;
     const ctx = canvas.getContext("2d");
-    canvas.width = 320;
-    canvas.height = 480;
 
-    const player = { x: canvas.width / 2 - 20, y: 400, vy: -8, w: 40, h: 40 };
+    const resize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    const player = {
+      x: canvas.width / 2 - 20,
+      y: canvas.height - 80,
+      vy: -8,
+      w: 40,
+      h: 40,
+    };
     const platforms = [];
     const pW = 60;
     const pH = 10;
@@ -73,8 +84,10 @@ export default function DoodleJumpGame({ onExit }) {
       }
 
       ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.textBaseline = "bottom";
+      ctx.font = player.h + "px sans-serif";
       ctx.fillStyle = "#fff";
-      ctx.fillRect(player.x, player.y, player.w, player.h);
+      ctx.fillText("🚀", player.x, player.y + player.h);
       ctx.fillStyle = "#0f0";
       platforms.forEach((p) => ctx.fillRect(p.x, p.y, pW, pH));
       ctx.fillStyle = "#fff";
@@ -88,11 +101,12 @@ export default function DoodleJumpGame({ onExit }) {
       cancelAnimationFrame(animId);
       window.removeEventListener("keydown", keyDown);
       window.removeEventListener("keyup", keyUp);
+      window.removeEventListener("resize", resize);
     };
-  }, [score]);
+  }, []);
 
   return (
-    <div className="text-white flex flex-col items-center">
+    <div className="text-white flex flex-col items-center justify-center w-screen h-screen">
       {gameOver && (
         <div className="mb-4 text-center">
           <p className="text-xl">Game Over</p>
@@ -100,7 +114,7 @@ export default function DoodleJumpGame({ onExit }) {
           <Button onClick={onExit}>В меню</Button>
         </div>
       )}
-      <canvas ref={canvasRef} className="border border-white" />
+      <canvas ref={canvasRef} className="w-full h-full border border-white block" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- make the root container stretch to the full viewport
- render the game overlay in full screen when a game mode is selected
- resize the canvas to `window` size and listen for resize
- draw a rocket instead of a square for the player

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685668c5c3b48329b79f50de142e75b2