### PR TITLE
Add SpaceJump gameplay

### DIFF
--- a/src/components/SpaceJumpMainMenu.jsx
+++ b/src/components/SpaceJumpMainMenu.jsx
@@ -9,7 +9,7 @@ import {
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "./ui/button";
-import GameScene from "./game/GameScene";
+import DoodleJumpGame from "./game/DoodleJumpGame";
 
 export default function SpaceJumpMainMenu() {
   const [screen, setScreen] = useState("menu");
@@ -39,7 +39,7 @@ export default function SpaceJumpMainMenu() {
       case "profile":
         return <Profile />;
       case "free":
-        return <GameScene onExit={() => setScreen("menu")} />;
+        return <DoodleJumpGame onExit={() => setScreen("menu")} />;
       case "ton":
         return <About />;
       case "settings":


### PR DESCRIPTION
## Summary
- implement playable Doodle Jump logic with coins and moving platforms
- show the game when selecting Free mode

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685671e3cc0883299a3d9d6fa75d409d