### PR TITLE
Fix menu visibility on start

### DIFF
--- a/game.js
+++ b/game.js
@@ -223,3 +223,8 @@ document.addEventListener('keydown', e => {
 document.addEventListener('keyup', e => {
   keys[e.key] = false;
 });
+
+// Show the main menu when the page first loads
+window.addEventListener('DOMContentLoaded', () => {
+  menu.classList.add('show');
+});


### PR DESCRIPTION
## Summary
- ensure the start menu becomes visible when the page loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856e182b4d4832981292e6326912229