### PR TITLE
Add music and sprite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,22 @@ SpaceJump is a simplified Doodle Jump style game intended to be used as a Telegr
 - Rocket shows a flame when moving upward
 - A floor at the start so the rocket doesn't immediately fall
 - Scrolling star background
+- Optional background music and sound effects
+- Support for sprite images for the rocket and platforms
 
 ## Running Locally
 
 Simply open `index.html` in a browser to play the game locally.
+
+The game expects audio and image assets inside an `assets` directory:
+
+- `assets/rocket.png` – sprite for the rocket
+- `assets/platform.png` – sprite for platforms
+- `assets/jump.wav` – jump sound effect
+- `assets/gameover.wav` – game over sound
+- `assets/music.mp3` – background music
+
+You can replace these with your own files to customize the look and sound.
 
 ## Deploying as a Telegram Web Game
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,3 @@
+Placeholder directory for game sprites and sounds. Add your own
+`rocket.png`, `platform.png`, `jump.wav`, `gameover.wav` and `music.mp3`
+files here to customize the game.

--- a/game.js
+++ b/game.js
@@ -5,7 +5,17 @@ const startButton = document.getElementById('startButton');
 const scoreboard = document.getElementById('scoreboard');
 const scoreElement = document.getElementById('score');
 const bestScoreElement = document.getElementById('best-score');
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const musicToggle = document.getElementById('musicToggle');
+const jumpSound = new Audio('assets/jump.wav');
+const gameOverSound = new Audio('assets/gameover.wav');
+const music = new Audio('assets/music.mp3');
+music.loop = true;
+
+const rocketImg = new Image();
+rocketImg.src = 'assets/rocket.png';
+
+const platformImg = new Image();
+platformImg.src = 'assets/platform.png';
 
 let gameRunning = false;
 let rocket;
@@ -35,24 +45,14 @@ function initStars() {
   }
 }
 
-function playSound(freq, duration, type = 'sine') {
-  const osc = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-  osc.type = type;
-  osc.frequency.value = freq;
-  osc.connect(gain);
-  gain.connect(audioCtx.destination);
-  gain.gain.setValueAtTime(0.2, audioCtx.currentTime);
-  osc.start();
-  osc.stop(audioCtx.currentTime + duration);
-}
-
 function playJumpSound() {
-  playSound(520, 0.1, 'triangle');
+  jumpSound.currentTime = 0;
+  jumpSound.play();
 }
 
 function playGameOverSound() {
-  playSound(220, 0.5, 'sawtooth');
+  gameOverSound.currentTime = 0;
+  gameOverSound.play();
 }
 const GRAVITY = 0.4;
 const GROUND_HEIGHT = 20;
@@ -198,24 +198,32 @@ function draw() {
   ctx.fillStyle = '#444';
   ctx.fillRect(ground.x, ground.y, ground.width, ground.height);
   // draw platforms
-  ctx.fillStyle = '#0f0';
   platforms.forEach(p => {
-    ctx.fillRect(p.x, p.y, p.width, p.height);
+    if (platformImg.complete) {
+      ctx.drawImage(platformImg, p.x, p.y, p.width, p.height);
+    } else {
+      ctx.fillStyle = '#0f0';
+      ctx.fillRect(p.x, p.y, p.width, p.height);
+    }
   });
   // draw rocket
-  ctx.fillStyle = '#fff';
-  ctx.fillRect(rocket.x + 15, rocket.y, 10, 30); // body
-  ctx.fillStyle = '#f00';
-  if (rocket.vy < 0) {
-    ctx.beginPath();
-    ctx.moveTo(rocket.x + 20, rocket.y + 30);
-    ctx.lineTo(rocket.x + 10, rocket.y + 40);
-    ctx.lineTo(rocket.x + 30, rocket.y + 40);
-    ctx.closePath();
-    ctx.fill();
+  if (rocketImg.complete) {
+    ctx.drawImage(rocketImg, rocket.x, rocket.y, rocket.width, rocket.height);
+  } else {
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(rocket.x + 15, rocket.y, 10, 30); // body
+    ctx.fillStyle = '#f00';
+    if (rocket.vy < 0) {
+      ctx.beginPath();
+      ctx.moveTo(rocket.x + 20, rocket.y + 30);
+      ctx.lineTo(rocket.x + 10, rocket.y + 40);
+      ctx.lineTo(rocket.x + 30, rocket.y + 40);
+      ctx.closePath();
+      ctx.fill();
+    }
+    ctx.fillStyle = '#0ff';
+    ctx.fillRect(rocket.x, rocket.y, 40, 10); // top
   }
-  ctx.fillStyle = '#0ff';
-  ctx.fillRect(rocket.x, rocket.y, 40, 10); // top
 }
 
 startButton.addEventListener('click', () => {
@@ -224,6 +232,19 @@ startButton.addEventListener('click', () => {
   canvas.style.display = 'block';
   scoreboard.style.display = 'block';
   init();
+  if (music.paused) {
+    music.play();
+  }
+});
+
+musicToggle.addEventListener('click', () => {
+  if (music.paused) {
+    music.play();
+    musicToggle.textContent = 'Music: On';
+  } else {
+    music.pause();
+    musicToggle.textContent = 'Music: Off';
+  }
 });
 
 document.addEventListener('keydown', e => {

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <canvas id="gameCanvas" style="display:none"></canvas>
   <div id="scoreboard" style="display:none">
     Score: <span id="score">0</span> | Best: <span id="best-score">0</span>
+    <button id="musicToggle">Music: On</button>
   </div>
   <script src="game.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -31,6 +31,11 @@ body {
   font-size: clamp(16px, 2vw, 24px);
 }
 
+#musicToggle {
+  margin-left: 1rem;
+  font-size: inherit;
+}
+
 @media (max-width: 600px) {
   #menu h1 {
     font-size: 2rem;


### PR DESCRIPTION
## Summary
- add a Music toggle button in the scoreboard
- support sprite images and audio files in game.js
- mention the new assets in README
- add placeholder assets directory

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856e52ee29883299db694d8758547d6