### PR TITLE
Fix initialization when DOM is already loaded

### DIFF
--- a/game.js
+++ b/game.js
@@ -260,10 +260,18 @@ document.addEventListener('keyup', e => {
   keys[e.key] = false;
 });
 
-// Show the main menu when the page first loads
-window.addEventListener('DOMContentLoaded', () => {
+// Show the main menu when the page first loads. When the script is loaded
+// after DOMContentLoaded has already fired (e.g. because it is placed at the
+// bottom of the page), run the initialization immediately.
+function showMenu() {
   resizeCanvas();
   menu.classList.add('show');
-});
+}
+
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', showMenu);
+} else {
+  showMenu();
+}
 
 window.addEventListener('resize', resizeCanvas);


### PR DESCRIPTION
## Summary
- initialize UI immediately if the script loads after DOMContentLoaded

## Testing
- `node -c game.js`

------
https://chatgpt.com/codex/tasks/task_e_6856e9abc79c832982b9a2749836e80c